### PR TITLE
splat args for New

### DIFF
--- a/passthrough.go
+++ b/passthrough.go
@@ -10,7 +10,7 @@ type Client struct {
 	Headers []string
 }
 
-func New(headers []string) *Client {
+func New(headers ...string) *Client {
 	return &Client{headers}
 }
 

--- a/passthrough_test.go
+++ b/passthrough_test.go
@@ -13,7 +13,7 @@ func TestPassHeaders(t *testing.T) {
 
 	res, w := Get(srv)
 
-	p := New([]string{"Content-Type"})
+	p := New("Content-Type")
 	p.PassHeaders(res.Header, w)
 
 	head := w.Header()
@@ -36,7 +36,7 @@ func TestPass(t *testing.T) {
 
 	res, w := Get(srv)
 
-	p := New([]string{"Content-Type"})
+	p := New("Content-Type")
 	p.Pass(res, w, 200)
 
 	if w.Status != 200 {


### PR DESCRIPTION
Have you thought about using `...string` notation instead of `[]string`? You get the same results, but `New("a","b","c")` is easier to read.
