### PR TITLE
Handle `Transfer-Encoding`

### DIFF
--- a/passthrough.go
+++ b/passthrough.go
@@ -16,7 +16,14 @@ func New(headers []string) *Client {
 
 func (c *Client) Pass(res *http.Response, w http.ResponseWriter, status int) {
 	head := c.PassHeaders(res.Header, w)
-	head.Set("Content-Length", strconv.Itoa(int(res.ContentLength)))
+	cl := int(res.ContentLength)
+	if cl == -1 {
+		for _, te := range res.TransferEncoding {
+			head.Add("Transfer-Encoding", te)
+		}
+	} else {
+		head.Set("Content-Length", strconv.Itoa(cl))
+	}
 	w.WriteHeader(status)
 	io.Copy(w, res.Body)
 	res.Body.Close()


### PR DESCRIPTION
Previously, this library would explicitly set the `Content-Length`
header on the passed-through response to the value of the
`ContentLength` property on the response object being passed.

However, `Content-Length` and `Transfer-Encoding` are mutually
exclusive - when `Transfer-Encoding` is used, the Go http package
will set the `ContentLength` property to `-1` to indicate no value.

This commit updates `go-passthrough` to handle this case. If the
`ContentLength` property is set to `-1`, the library will now
pass-through the `Transfer-Encoding` header instead of
`Content-Length`.

This PR is based on a fix developed by @tquinn86